### PR TITLE
Consumer disable

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,14 +4,14 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.github.koushikr</groupId>
   <artifactId>qtrouper</artifactId>
-  <version>0.0.10</version>
+  <version>0.1.0</version>
   <packaging>jar</packaging>
     <properties>
         <!-- github server corresponds to entry in ~/.m2/settings.xml -->
         <github.global.server>github</github.global.server>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <dropwizard.version>1.2.2</dropwizard.version>
-        <lombok.version>1.16.18</lombok.version>
+        <lombok.version>1.18.6</lombok.version>
         <guava.version>23.0</guava.version>
         <junit.version>4.12</junit.version>
         <mockito.version>2.9.0</mockito.version>

--- a/src/main/java/com/github/qtrouper/Trouper.java
+++ b/src/main/java/com/github/qtrouper/Trouper.java
@@ -289,7 +289,7 @@ public abstract class Trouper<Message extends QueueContext> {
         connection.ensure(getSidelineQueue(), this.config.getNamespace(), connection.rmqOpts());
 
 
-        if (config.isConsumerAvailable()) {
+        if (!config.isConsumerDisabled()) {
             for (int i = 1; i <= config.getConcurrency(); i++) {
                 Channel consumeChannel = connection.newChannel();
                 final Handler handler = new Handler(consumeChannel,

--- a/src/main/java/com/github/qtrouper/core/config/QueueConfiguration.java
+++ b/src/main/java/com/github/qtrouper/core/config/QueueConfiguration.java
@@ -36,8 +36,7 @@ public class QueueConfiguration {
     @Builder.Default
     private int prefetchCount = 1;
 
-    @Builder.Default
-    private boolean consumerAvailable=true;
+    private boolean consumerDisabled;
 
     private RetryConfiguration retry;
 

--- a/src/test/java/com/github/qtrouper/TrouperTest.java
+++ b/src/test/java/com/github/qtrouper/TrouperTest.java
@@ -110,7 +110,7 @@ public class TrouperTest {
                 .namespace(DEFAULT_NAMESPACE)
                 .concurrency(0)
                 .prefetchCount(10)
-                .consumerAvailable(false)
+                .consumerDisabled(true)
                 .build();
 
         getTrouperAfterStart(queueConfiguration);
@@ -123,7 +123,7 @@ public class TrouperTest {
                 .namespace(DEFAULT_NAMESPACE)
                 .concurrency(0)
                 .prefetchCount(10)
-                .consumerAvailable(true)
+                .consumerDisabled(false)
                 .retry(getRetryConfiguration(false, 10))
                 .sideline(getSidelineConfiguration(false, 0))
                 .build();
@@ -138,7 +138,7 @@ public class TrouperTest {
                 .namespace(DEFAULT_NAMESPACE)
                 .concurrency(0)
                 .prefetchCount(10)
-                .consumerAvailable(true)
+                .consumerDisabled(false)
                 .retry(getRetryConfiguration(false, 10))
                 .sideline(getSidelineConfiguration(true, 1))
                 .build();
@@ -157,7 +157,7 @@ public class TrouperTest {
                 .namespace(DEFAULT_NAMESPACE)
                 .concurrency(10)
                 .prefetchCount(10)
-                .consumerAvailable(true)
+                .consumerDisabled(false)
                 .retry(getRetryConfiguration(false, 10))
                 .sideline(getSidelineConfiguration(true, 10))
                 .build();

--- a/src/test/java/com/github/qtrouper/core/config/QueueConfigurationTest.java
+++ b/src/test/java/com/github/qtrouper/core/config/QueueConfigurationTest.java
@@ -1,0 +1,34 @@
+package com.github.qtrouper.core.config;
+
+import static org.junit.Assert.*;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class QueueConfigurationTest {
+
+  @Test
+  public void testQueueConfigurationDefaultViaConstructor() {
+
+
+    QueueConfiguration queueConfiguration = new QueueConfiguration();
+
+    Assert.assertFalse(queueConfiguration.isConsumerDisabled());
+    Assert.assertEquals(queueConfiguration.getConcurrency(), 3);
+    Assert.assertEquals(queueConfiguration.getNamespace(), "qtrouper");
+
+
+  }
+
+  @Test
+  public void testQueueConfigurationDefaultViaBuilder() {
+
+    QueueConfiguration queueViaBuilder = QueueConfiguration.builder().build();
+
+    Assert.assertFalse(queueViaBuilder.isConsumerDisabled());
+    Assert.assertEquals(queueViaBuilder.getConcurrency(), 3);
+    Assert.assertEquals(queueViaBuilder.getNamespace(), "qtrouper");
+
+  }
+
+}


### PR DESCRIPTION
Making a breaking change of to consumerDisabled (was consumerAvailable before)
Updating the lombok version to ensure defaults are used in both builder and constructor based creation. Added test case for the same