### PR TITLE
Added changeLog to trouper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+### Version 0.0.1-1
+
+- Added default handling to QTrouper.handle in case the properties object goes missing or when the headers are not present.
+- Doing a minor, for this is a bug fix. 
+
+## Impact
+
+If you are using trouper to publish messages and read off it, this won't impact you. But when you are publishing messages using another RMQ client or an adhoc script that pushes messages into the queue without the headers, required (that trouper would've organically added), you'll see this issue. 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.github.qtrouper</groupId>
     <artifactId>qtrouper</artifactId>
-    <version>0.0.1</version>
+    <version>0.0.1-1</version>
     <packaging>jar</packaging>
 
     <licenses>


### PR DESCRIPTION
Added changeLog to trouper
Minor update 0.0.1-1

Handler for null properties. Fix.

If you are using trouper to publish messages and read off it, this won't impact you. But when you are publishing messages using another RMQ client or an adhoc script that pushes messages into the queue without the headers, required (that trouper would've organically added), you'll see this issue.