### PR TITLE
Adding message expiry config over queue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <lombok.version>1.18.6</lombok.version>
     <guava.version>23.0</guava.version>
-    <junit.version>4.12</junit.version>
+    <junit.version>5.4.0</junit.version>
     <mockito.version>2.9.0</mockito.version>
     <cglib.version>3.2.5</cglib.version>
 
@@ -75,8 +75,8 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
       <version>${junit.version}</version>
       <scope>test</scope>
     </dependency>

--- a/qtrouper-core/src/main/java/io/github/qtrouper/core/config/MessageExpiryConfiguration.java
+++ b/qtrouper-core/src/main/java/io/github/qtrouper/core/config/MessageExpiryConfiguration.java
@@ -15,16 +15,14 @@
  */
 package io.github.qtrouper.core.config;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
 
-import javax.validation.constraints.Max;
-import javax.validation.constraints.Min;
-
-/**
- * @author koushik
- */
 @Data
 @EqualsAndHashCode
 @ToString
@@ -32,36 +30,17 @@ import javax.validation.constraints.Min;
 @NoArgsConstructor
 @Builder
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class QueueConfiguration {
+public class MessageExpiryConfiguration {
 
-    private static final String DEFAULT_NAMESPACE = "qtrouper";
+  private boolean enabled;
 
-    @Builder.Default
-    private String namespace = DEFAULT_NAMESPACE;
+  private long thresholdInMs; // If threshold is breached given action will be taken
 
-    private String queueName;
+  private MessageExpiryAction action;
 
-    @Min(1)
-    @Max(100)
-    @Builder.Default
-    private int concurrency = 3;
-
-    @Min(1)
-    @Max(100)
-    @Builder.Default
-    private int prefetchCount = 1;
-
-    private boolean consumerDisabled;
-
-    private RetryConfiguration retry;
-
-    private SidelineConfiguration sideline;
-
-    private MessageExpiryConfiguration messageExpiry;
-
-    @JsonIgnore
-    public boolean isConsumerEnabled(){
-        return !consumerDisabled;
-    }
+  public enum MessageExpiryAction {
+    SIDELINE,
+    IGNORE;
+  }
 
 }

--- a/qtrouper-core/src/main/java/io/github/qtrouper/core/config/MessageExpiryConfiguration.java
+++ b/qtrouper-core/src/main/java/io/github/qtrouper/core/config/MessageExpiryConfiguration.java
@@ -36,7 +36,8 @@ public class MessageExpiryConfiguration {
 
   private long thresholdInMs; // If threshold is breached given action will be taken
 
-  private MessageExpiryAction action;
+  @Builder.Default
+  private MessageExpiryAction action = MessageExpiryAction.IGNORE;
 
   public enum MessageExpiryAction {
     SIDELINE,

--- a/qtrouper-core/src/test/java/io/github/qtrouper/TrouperTest.java
+++ b/qtrouper-core/src/test/java/io/github/qtrouper/TrouperTest.java
@@ -25,15 +25,15 @@ import io.github.qtrouper.core.models.QAccessInfo;
 import io.github.qtrouper.core.models.QueueContext;
 import io.github.qtrouper.core.rabbit.RabbitConfiguration;
 import io.github.qtrouper.core.rabbit.RabbitConnection;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static org.mockito.Mockito.*;
 
@@ -81,7 +81,7 @@ public class TrouperTest {
         .build();
   }
 
-  @Before
+  @BeforeEach
   public void setup() throws IOException {
     this.rabbitConnection = mock(RabbitConnection.class);
   }
@@ -162,7 +162,7 @@ public class TrouperTest {
 
     Trouper trouper = getTrouperAfterStart(queueConfiguration);
 
-    Assert.assertTrue(trouper.getHandlers().size() == 1);
+    Assertions.assertEquals(1, trouper.getHandlers().size());
   }
 
   @Test
@@ -179,6 +179,6 @@ public class TrouperTest {
 
     Trouper trouper = getTrouperAfterStart(queueConfiguration);
 
-    Assert.assertTrue(trouper.getHandlers().size() == 20);
+    Assertions.assertEquals(20, trouper.getHandlers().size());
   }
 }

--- a/qtrouper-core/src/test/java/io/github/qtrouper/core/config/MessageExpiryConfigurationTest.java
+++ b/qtrouper-core/src/test/java/io/github/qtrouper/core/config/MessageExpiryConfigurationTest.java
@@ -1,0 +1,30 @@
+package io.github.qtrouper.core.config;
+
+import static io.github.qtrouper.core.config.MessageExpiryConfiguration.MessageExpiryAction.IGNORE;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class MessageExpiryConfigurationTest {
+
+  @Test
+  public void testWhenMessageExpiryConfigurationDefaultViaConstructor() {
+
+    MessageExpiryConfiguration messageExpiryConfiguration = new MessageExpiryConfiguration();
+
+    Assertions.assertFalse(messageExpiryConfiguration.isEnabled());
+    Assertions.assertEquals(0L, messageExpiryConfiguration.getThresholdInMs());
+    Assertions.assertEquals(IGNORE, messageExpiryConfiguration.getAction());
+  }
+
+  @Test
+  public void testWhenMessageExpiryConfigurationDefaultViaBuilder() {
+
+    MessageExpiryConfiguration messageExpiryConfiguration = MessageExpiryConfiguration.builder().build();
+
+    Assertions.assertFalse(messageExpiryConfiguration.isEnabled());
+    Assertions.assertEquals(0L, messageExpiryConfiguration.getThresholdInMs());
+    Assertions.assertEquals(IGNORE, messageExpiryConfiguration.getAction());
+  }
+
+}

--- a/qtrouper-core/src/test/java/io/github/qtrouper/core/config/QueueConfigurationTest.java
+++ b/qtrouper-core/src/test/java/io/github/qtrouper/core/config/QueueConfigurationTest.java
@@ -15,8 +15,9 @@
  */
 package io.github.qtrouper.core.config;
 
-import org.junit.Assert;
-import org.junit.Test;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class QueueConfigurationTest {
 
@@ -26,9 +27,9 @@ public class QueueConfigurationTest {
 
     QueueConfiguration queueConfiguration = new QueueConfiguration();
 
-    Assert.assertFalse(queueConfiguration.isConsumerDisabled());
-    Assert.assertEquals(queueConfiguration.getConcurrency(), 3);
-    Assert.assertEquals(queueConfiguration.getNamespace(), "qtrouper");
+    Assertions.assertFalse(queueConfiguration.isConsumerDisabled());
+    Assertions.assertEquals(queueConfiguration.getConcurrency(), 3);
+    Assertions.assertEquals(queueConfiguration.getNamespace(), "qtrouper");
 
 
   }
@@ -38,9 +39,9 @@ public class QueueConfigurationTest {
 
     QueueConfiguration queueViaBuilder = QueueConfiguration.builder().build();
 
-    Assert.assertFalse(queueViaBuilder.isConsumerDisabled());
-    Assert.assertEquals(queueViaBuilder.getConcurrency(), 3);
-    Assert.assertEquals(queueViaBuilder.getNamespace(), "qtrouper");
+    Assertions.assertFalse(queueViaBuilder.isConsumerDisabled());
+    Assertions.assertEquals(queueViaBuilder.getConcurrency(), 3);
+    Assertions.assertEquals(queueViaBuilder.getNamespace(), "qtrouper");
 
   }
 

--- a/qtrouper-core/trouper.md
+++ b/qtrouper-core/trouper.md
@@ -1,0 +1,85 @@
+# All about [Trouper](https://github.com/koushikr/qtrouper/blob/master/qtrouper-core/src/main/java/io/github/qtrouper/Trouper.java)
+> A reliable and uncomplaining actor, give all the messages you have and trouper is happy to consume
+
+## Basics
+- `Trouper` is a abstract class which acts as a processor for one queue, handling publishing, consuming, retrying, sidelining
+- Each trouper needs a `QueueConfiguration` to understand your needs on queue functionality and message processing. Know more about `QueueConfiguration` [here](https://todo.next)
+- Each trouper would also need some basic details like queueName, messageJavaType, knownExceptionTypes required for processing.
+- For each trouper all you have to do is implement a method, how you would like to process the message, that's it!
+
+So a trouper would like something like this:
+```java
+public class NotificationSender extends Trouper<NotificationMessage> {
+
+    private final NotificationService notificationService;
+
+    public NotificationSender() {
+        super("NOTIFICATION_SENDER_QUEUE", // queueName
+            queueConfiguration, // required queue config
+            rabbitConnection, // RMQ connection
+            NotificationMessage.class, // messageClassType
+            Collections.emptySet()); // known exceptions set
+        notificationService = new NotificationService();
+    }
+
+    @Override
+    public boolean process(NotificationMessage notificationMessage, QAccessInfo accessInfo) {
+        notificationService.notify(notificationMessage);
+        return true;
+    }
+
+    @Override
+    public boolean processSideline(NotificationMessage notificationMessage, QAccessInfo accessInfo) {
+        process(notificationMessage, accessInfo);
+        return true;
+    }
+}
+```
+
+## Understanding interface
+We can break the complete trouper interface into three areas
+- Init's
+- Publish
+- Consume
+
+### Init's
+```java
+void start() // Required to be called before using any of trouper functionality
+```
+```java
+void stop() // Required to be called before shutting down the application
+```
+
+### Publish
+Multiple options on how we can publish a message
+```java
+void publish(Message message) 
+// Publishes the message to mainQueue in persistent mode
+```
+```java
+void publishWithExpiry(Message message, long expiresAt, boolean expiresAtEnabled) 
+// Publishes the message which gets expired at given timestamp if expiration is enabled
+```
+```java
+void sidelinePublish(Message message) 
+//  Publishes the message to sideline queue
+```
+```java
+void retryPublish(Message message, int retryCount, long expiration) 
+// Publishes the message to retry queue with retryCount and expiration which would further deadLetter into the mainQueue.
+```
+```java
+void retryPublishWithExpiry(Message message, int retryCount, long expiration, long expiresAt, boolean expiresAtEnabled) 
+// Publishes the message to retry queue with retryCount and expiration and expiryTimestamp which would further deadLetter into the mainQueue
+```
+
+### Consume
+Below consume methods are abstract and needs to implemented by the concrete class
+```java
+abstract boolean process(Message message, QAccessInfo accessInfo) 
+// Process message on main queue and return's true if successfully processed
+```
+```java
+abstract boolean processSideline(Message message, QAccessInfo accessInfo) 
+// Process message on sideline queue and return's true if successfully processed
+```

--- a/qtrouper-dw/src/test/java/io/github/qtrouper/healthchecks/TrouperHealthCheckTest.java
+++ b/qtrouper-dw/src/test/java/io/github/qtrouper/healthchecks/TrouperHealthCheckTest.java
@@ -1,0 +1,74 @@
+package io.github.qtrouper.healthchecks;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.codahale.metrics.health.HealthCheck.Result;
+import com.rabbitmq.client.Channel;
+import com.rabbitmq.client.Connection;
+import io.github.qtrouper.core.rabbit.RabbitConnection;
+import java.io.IOException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class TrouperHealthCheckTest {
+
+  private RabbitConnection rabbitConnection;
+  private TrouperHealthCheck trouperHealthCheck;
+
+  @BeforeEach
+  public void setUp() {
+    rabbitConnection = mock(RabbitConnection.class);
+    trouperHealthCheck = new TrouperHealthCheck(rabbitConnection);
+  }
+
+  @Test
+  public void testWhenConnectionIsNull() throws Exception {
+    when(rabbitConnection.getConnection()).thenReturn(null);
+
+    Result result = trouperHealthCheck.check();
+
+    Assertions.assertFalse(result.isHealthy());
+    Assertions.assertEquals("Not Connected", result.getMessage());
+  }
+
+  @Test
+  public void testWhenConnectionIsNotOpen() throws Exception {
+    Connection connection = mock(Connection.class);
+    when(connection.isOpen()).thenReturn(false);
+    when(rabbitConnection.getConnection()).thenReturn(connection);
+
+    Result result = trouperHealthCheck.check();
+
+    Assertions.assertFalse(result.isHealthy());
+    Assertions.assertEquals("Not Connected", result.getMessage());
+  }
+
+  @Test
+  public void testWhenConnectionIsOpenButExceptionWithChannel() throws Exception {
+    Connection connection = mock(Connection.class);
+    when(connection.isOpen()).thenReturn(true);
+    when(connection.createChannel()).thenThrow(new IOException());
+    when(rabbitConnection.getConnection()).thenReturn(connection);
+
+    Result result = trouperHealthCheck.check();
+
+    Assertions.assertFalse(result.isHealthy());
+    Assertions.assertEquals("Connection is open, could not create channel", result.getMessage());
+  }
+
+  @Test
+  public void testWhenConnectionIsOpenAndOperational() throws Exception {
+    Connection connection = mock(Connection.class);
+    when(connection.isOpen()).thenReturn(true);
+    Channel channel = mock(Channel.class);
+    when(connection.createChannel()).thenReturn(channel);
+    when(rabbitConnection.getConnection()).thenReturn(connection);
+
+    Result result = trouperHealthCheck.check();
+
+    Assertions.assertTrue(result.isHealthy());
+  }
+
+}


### PR DESCRIPTION
#### What's happening?
Adding support for messages expiry as config to be applied for message that is being published to a queue

#### What's the need?
There would be use-cases where if a message is not consumed/processed in a specific time range then processing that message would not be required.  For example: If you are publishing a message to relay a status and say this status is updated every minute. If the message is not processed in a minute then processing that message is not required as the response is already stale

#### What's the change?
A new config `MessageExpiryConfiguration` is added to queue configuration. Before every publish there is check for message expiry and if so adds the details and publish else basic publish. 
_Please note that this config set to a specific queue is can be overridden for specific messages by `publishWithExpiry` method_