### PR TITLE
Exception handling for Trouper.process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### Version 0.0.2
 
-- Added exception handling in `Trouper.handle` for exceptions thrown from `Trouper.process`  
+- Added exception handling in `Trouper.handle` for exceptions thrown from `Trouper.process`.
+- Fix number of retries which is making one extra retry always if enabled.
 
 ### Version 0.0.1-1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### Version 0.0.2
+
+- Added exception handling in `Trouper.handle` for exceptions thrown from `Trouper.process`  
+
 ### Version 0.0.1-1
 
 - Added default handling to QTrouper.handle in case the properties object goes missing or when the headers are not present.

--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,7 @@
         <mockito.version>2.9.0</mockito.version>
         <cglib.version>3.2.5</cglib.version>
         <amqp.version>4.8.0</amqp.version>
+        <testcontainer.rabbitmq.version>1.16.2</testcontainer.rabbitmq.version>
 
         <!--Jacoco properties-->
         <jacoco.version>0.8.0</jacoco.version>
@@ -105,6 +106,15 @@
             <artifactId>amqp-client</artifactId>
             <version>${amqp.version}</version>
         </dependency>
+
+        <!-- Test Dependencies -->
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>rabbitmq</artifactId>
+            <version>${testcontainer.rabbitmq.version}</version>
+            <scope>test</scope>
+        </dependency>
+
 
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.github.qtrouper</groupId>
     <artifactId>qtrouper</artifactId>
-    <version>0.0.1-1</version>
+    <version>0.0.2</version>
     <packaging>jar</packaging>
 
     <licenses>
@@ -28,6 +28,11 @@
             <id>koushikr</id>
             <name>Koushik Ramachandra</name>
             <email>rkoushik.14@gmail.com</email>
+        </developer>
+        <developer>
+            <id>chaitanyachavali</id>
+            <name>Chaitanya Reddy</name>
+            <email>chaitanyachavali7@gmail.com</email>
         </developer>
     </developers>
 

--- a/src/main/java/io/github/qtrouper/Trouper.java
+++ b/src/main/java/io/github/qtrouper/Trouper.java
@@ -114,7 +114,14 @@ public abstract class Trouper<Message extends QueueContext> {
             return true;
         }
 
-        boolean processed = process(message, getAccessInformation(properties));
+        boolean processed;
+
+        try {
+            processed = process(message, getAccessInformation(properties));
+        } catch (Exception ex) {
+            log.error("Exception while processing the message {}", message, ex);
+            processed = false;
+        }
 
         if (processed) return true;
 

--- a/src/main/java/io/github/qtrouper/Trouper.java
+++ b/src/main/java/io/github/qtrouper/Trouper.java
@@ -131,7 +131,7 @@ public abstract class Trouper<Message extends QueueContext> {
 
             int retryCount = (int) properties.getHeaders().getOrDefault(RETRY_COUNT, 0);
 
-            if (retryCount > retry.getMaxRetries()) {
+            if (retryCount >= retry.getMaxRetries()) {
                 sidelinePublish(message);
                 return true;
             }

--- a/src/test/java/io/github/qtrouper/BaseRMQSetupTest.java
+++ b/src/test/java/io/github/qtrouper/BaseRMQSetupTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2019 Koushik R <rkoushik.14@gmail.com>.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.qtrouper;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.Lists;
+import io.github.qtrouper.core.rabbit.RabbitBroker;
+import io.github.qtrouper.core.rabbit.RabbitConfiguration;
+import io.github.qtrouper.core.rabbit.RabbitConnection;
+import io.github.qtrouper.utils.SerDe;
+import java.io.IOException;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.testcontainers.containers.RabbitMQContainer;
+
+@Slf4j
+public abstract class BaseRMQSetupTest {
+
+  protected static RabbitMQContainer rabbitMQContainer;
+  protected static RabbitConnection rabbitConnection;
+
+  @BeforeClass
+  public static void setUp() throws Exception {
+    // Create and start rabbitmq-docker-instance
+    rabbitMQContainer = new RabbitMQContainer("rabbitmq:3-alpine");
+    rabbitMQContainer.start();
+
+    // Create RabbitConnection for troupers
+    rabbitConnection = new RabbitConnection(getRabbitConfiguration());
+    rabbitConnection.start();
+
+    SerDe.init(new ObjectMapper());
+  }
+
+  @AfterClass
+  public static void tearDown() throws Exception {
+    rabbitConnection.stop();
+    rabbitMQContainer.stop();
+  }
+
+  protected void waitTillQueueIsEmpty(String queueName) throws IOException, InterruptedException {
+    int count = 0;
+    int maxCount = 100;
+    while (true) {
+      long currentCount = rabbitConnection.getChannel().messageCount(queueName);
+      log.info("Current queue size for {} is {}", queueName, currentCount);
+      if (currentCount == 0) {
+        return;
+      }
+      Thread.sleep(100);
+      count++;
+      if (count == maxCount) {
+        throw new RuntimeException("Queues not getting cleared in the test");
+      }
+    }
+  }
+
+  private static RabbitConfiguration getRabbitConfiguration() {
+    return RabbitConfiguration.builder()
+        .brokers(Lists.newArrayList(RabbitBroker.builder()
+            .host(rabbitMQContainer.getHost())
+            .port(rabbitMQContainer.getAmqpPort())
+            .build()))
+        .threadPoolSize(10)
+        .userName("guest")
+        .password("guest")
+        .virtualHost("/")
+        .build();
+  }
+
+}

--- a/src/test/java/io/github/qtrouper/TrouperExceptionHandlingTest.java
+++ b/src/test/java/io/github/qtrouper/TrouperExceptionHandlingTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2019 Koushik R <rkoushik.14@gmail.com>.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.qtrouper;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.github.qtrouper.core.config.QueueConfiguration;
+import io.github.qtrouper.core.config.RetryConfiguration;
+import io.github.qtrouper.core.config.SidelineConfiguration;
+import io.github.qtrouper.core.models.QAccessInfo;
+import io.github.qtrouper.core.models.QueueContext;
+import io.github.qtrouper.core.rabbit.RabbitConnection;
+import java.util.Collections;
+import java.util.Set;
+import org.junit.Before;
+import org.junit.Test;
+
+public class TrouperExceptionHandlingTest extends BaseRMQSetupTest {
+
+  @Before
+  public void setUpForEachRun() {
+    checkIdDependenciesAreReady();
+  }
+
+  private void checkIdDependenciesAreReady() {
+    if (!rabbitMQContainer.isRunning()) {
+      throw new RuntimeException("RabbitMQ is not ready to execute test");
+    }
+    if (rabbitConnection.getConnection() == null || rabbitConnection.getChannel() == null) {
+      throw new RuntimeException("RabbitConnection is not made yet");
+    }
+  }
+
+  @Test
+  public void testWhenProcessThrowsException() throws Exception {
+    QueueConfiguration queueConfiguration = QueueConfiguration.builder()
+        .queueName("TEST_QUEUE_1")
+        .concurrency(1)
+        .prefetchCount(1)
+        .retry(RetryConfiguration.builder()
+            .ttlMs(8000)
+            .backOffFactor(0)
+            .maxRetries(1)
+            .enabled(true)
+            .build())
+        .sideline(SidelineConfiguration.builder()
+            .concurrency(1)
+            .enabled(true)
+            .build())
+        .build();
+
+    ExceptionInterface exceptionInterface = mock(ExceptionInterface.class);
+
+    when(exceptionInterface.process()).thenThrow(new RuntimeException("test"));
+    when(exceptionInterface.processSideline()).thenReturn(true);
+
+    // Create and start a Trouper
+    ExceptionTrouper trouper = new ExceptionTrouper(queueConfiguration.getQueueName(),
+        queueConfiguration, rabbitConnection, QueueContext.class, Collections.emptySet(),
+        exceptionInterface);
+    trouper.start();
+
+    // Publish a message to trouper
+    trouper.publish(QueueContext.builder().build());
+
+    Thread.sleep(1000);
+
+    verify(exceptionInterface, times(2)).process();
+    verify(exceptionInterface, times(1)).processSideline();
+  }
+
+
+  static class ExceptionTrouper extends Trouper<QueueContext> {
+
+    ExceptionInterface testInterface;
+
+    protected ExceptionTrouper(String queueName, QueueConfiguration config,
+        RabbitConnection connection, Class<? extends QueueContext> clazz,
+        Set<Class<?>> droppedExceptionTypes, ExceptionInterface testInterface) {
+      super(queueName, config, connection, clazz, droppedExceptionTypes);
+      this.testInterface = testInterface;
+    }
+
+    @Override
+    public boolean process(QueueContext queueContext, QAccessInfo accessInfo) {
+      return testInterface.process();
+    }
+
+    @Override
+    public boolean processSideline(QueueContext queueContext, QAccessInfo accessInfo) {
+      return testInterface.processSideline();
+    }
+  }
+
+  interface ExceptionInterface {
+    boolean process();
+    boolean processSideline();
+  }
+
+}


### PR DESCRIPTION
Fixing below issues in the version `0.0.1-1` and updating to `0.0.2`:
- If an exception is thrown in `Trouper.process` then it goes into a loop on requeueing the same message till it get processed. Made fix to publish to retry or sideline queue based on config instead of going into the loop.
- If retry is enabled the number of retries made are X+1 where X are the number of retries configured. Fixed to only make exact retries which are configured. 